### PR TITLE
Pin Claude Code version and disable auto-updater

### DIFF
--- a/base/.devcontainer/Dockerfile
+++ b/base/.devcontainer/Dockerfile
@@ -81,6 +81,7 @@ RUN sh -c "$(wget -O- https://github.com/deluan/zsh-in-docker/releases/download/
 
 # Install Claude
 RUN npm install -g @anthropic-ai/claude-code@1.0.53
+RUN echo "alias claude='DISABLE_AUTOUPDATER=1 claude'" >> /home/node/.zshrc
 
 # Copy and set up firewall script
 COPY init-firewall.sh /usr/local/bin/

--- a/base/.devcontainer/Dockerfile
+++ b/base/.devcontainer/Dockerfile
@@ -80,7 +80,7 @@ RUN sh -c "$(wget -O- https://github.com/deluan/zsh-in-docker/releases/download/
   -x
 
 # Install Claude
-RUN npm install -g @anthropic-ai/claude-code
+RUN npm install -g @anthropic-ai/claude-code@1.0.53
 
 # Copy and set up firewall script
 COPY init-firewall.sh /usr/local/bin/

--- a/rust/.devcontainer/Dockerfile
+++ b/rust/.devcontainer/Dockerfile
@@ -94,7 +94,7 @@ RUN sh -c "$(wget -O- https://github.com/deluan/zsh-in-docker/releases/download/
   -x
 
 # Install Claude
-RUN npm install -g @anthropic-ai/claude-code
+RUN npm install -g @anthropic-ai/claude-code@1.0.53
 
 # Copy and set up firewall script
 COPY init-firewall.sh /usr/local/bin/

--- a/rust/.devcontainer/Dockerfile
+++ b/rust/.devcontainer/Dockerfile
@@ -95,6 +95,7 @@ RUN sh -c "$(wget -O- https://github.com/deluan/zsh-in-docker/releases/download/
 
 # Install Claude
 RUN npm install -g @anthropic-ai/claude-code@1.0.53
+RUN echo "alias claude='DISABLE_AUTOUPDATER=1 claude'" >> /home/node/.zshrc
 
 # Copy and set up firewall script
 COPY init-firewall.sh /usr/local/bin/


### PR DESCRIPTION
## Summary
- Pin Claude Code version to 1.0.53 in both base and rust devcontainers
- Add alias to disable automatic updates via DISABLE_AUTOUPDATER environment variable

## Changes
- Specify `@anthropic-ai/claude-code@1.0.53` in npm install commands
- Add `alias claude='DISABLE_AUTOUPDATER=1 claude'` to .zshrc to prevent auto-updates

🤖 Generated with [Claude Code](https://claude.ai/code)